### PR TITLE
pip fix for upgrading to broken 8.1.2

### DIFF
--- a/docker/init.sls
+++ b/docker/init.sls
@@ -119,7 +119,6 @@ docker-py requirements:
     - name: pip {{ docker.pip.version }}
     {%- else %}
     - name: pip == 8.1.1
-    - upgrade: True
     {%- endif %}
 
 docker-py:


### PR DESCRIPTION
still seems to upgrade to latest 8.1.2, removing the upgrade to avoid this
